### PR TITLE
Issue #22 Fix: Changed out React Native clipboard with browser native Clipboard API

### DIFF
--- a/ui-frontend/.env
+++ b/ui-frontend/.env
@@ -1,1 +1,3 @@
 INLINE_RUNTIME_CHUNK=false
+#disables typescript warnings
+GENERATE_SOURCEMAP=false

--- a/ui-frontend/package.json
+++ b/ui-frontend/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "dependencies": {
     "@okta/okta-react": "6.3.0",
-    "@react-native-clipboard/clipboard": "^1.9.0",
     "@types/react-dom": "^16.9.13",
     "@types/react-router-dom": "^5.1.5",
     "aws-northstar": "1.3.11",

--- a/ui-frontend/src/components/Request/RequestTable.tsx
+++ b/ui-frontend/src/components/Request/RequestTable.tsx
@@ -7,7 +7,6 @@ import Table, { Column } from 'aws-northstar/components/Table';
 import {deleteRequest, getRequests, invokeFederateConsole, invokeFederateCli} from "../../data";
 import {ICredential, IRequest, ReduxRoot} from "../../interfaces";
 import '../home/styles.css';
-import Clipboard from '@react-native-clipboard/clipboard';
 
 import {
   ExpandableSection,
@@ -122,27 +121,27 @@ const RequestTable: FunctionComponent = () => {
 
     const copyJSONToClipboard = () => {
       let content = getJSON(cli)
-      Clipboard.setString(content)
+      navigator.clipboard.writeText(content);
     }
 
     const copyBashToClipboard = () => {
       let content = getBash(cli)
-      Clipboard.setString(content)
+      navigator.clipboard.writeText(content);
     }
 
     const copyFishToClipboard = () => {
       let content = getFish(cli)
-      Clipboard.setString(content)
+      navigator.clipboard.writeText(content);
     }
 
     const copyPowershellToClipboard = () => {
       let content = getPowershell(cli)
-      Clipboard.setString(content)
+      navigator.clipboard.writeText(content);
     }
 
     const copyWindowsToClipboard = () => {
       let content = getWindows(cli)
-      Clipboard.setString(content)
+      navigator.clipboard.writeText(content);
     }
 
     return (

--- a/ui-frontend/src/components/home/HomePageContent.tsx
+++ b/ui-frontend/src/components/home/HomePageContent.tsx
@@ -1,5 +1,5 @@
 import React, {FunctionComponent, useEffect, useState} from 'react';
-import {ColumnLayout, Column, Container, Box, Button} from "aws-northstar";
+import {ColumnLayout, Container, Box, Button} from "aws-northstar";
 import Stack from "aws-northstar/layouts/Stack";
 import './styles.css';
 import TEA from "./TEA.png";


### PR DESCRIPTION
Issue #22 Fix: https://github.com/aws-samples/aws-iam-temporary-elevated-access-broker/issues/22

React-Native uses a version of react that is several versions behind that of the main version. Rather than downgrading the apps react version to suit React-Native Clipboard it is better to replace it with a browser native Clipboard API.

Have confirmed that it works with my build. Please feel free to ping me if it needs changing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
