### PR TITLE
Fix 500 error when rejecting a request

### DIFF
--- a/ui-frontend/src/components/Request/RequestForm.tsx
+++ b/ui-frontend/src/components/Request/RequestForm.tsx
@@ -263,6 +263,7 @@ function get_roles(account:string,userInfo: IUserInfo) {
 function get_accounts_values(userInfo: IUserInfo) {
   let accounts = get_accounts(userInfo)
   let list: Array<any> = [];
+  accounts.sort();
   for (var account of accounts) {
     list.push({label: account, value: account});
   }

--- a/ui-frontend/src/components/Review/PendingTable.tsx
+++ b/ui-frontend/src/components/Review/PendingTable.tsx
@@ -168,7 +168,7 @@ const PendingTable: FunctionComponent = () => {
             return result;
           });
 
-      let requests = await getPendingRequests(userInfo.user).then(
+      let requests = await getPendingRequests(userInfo.token).then(
           (result: IRequest[]) => {
             return result;
           });


### PR DESCRIPTION
*Issue #24:*

Made a change to the PendingTable file to fix a 500 bug when rejecting a request.
Sorting the list of accounts in the 'create request' form.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
